### PR TITLE
Corrected spelling of pdf viewer in plugin.json : #115452045

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "author":"BuildFire"
-  ,"pluginName":"PDF Viwer"
+  ,"pluginName":"PDF Viewer"
   ,"pluginDescription":"The PDF Viewer plugin allows you to link to external PDF files."
   ,"supportEmail":"support@buildfire.com"
   ,"pluginIcon":"icon.png"


### PR DESCRIPTION
Fixed issue : "In the configuration section, the Pdf Viewer is spelled wrong. Right now its spelled "PDF Viwer". The spelling just needs to be fixed"
